### PR TITLE
Add main page env var

### DIFF
--- a/src/signal_documentation/settings.py
+++ b/src/signal_documentation/settings.py
@@ -183,6 +183,7 @@ MEDIA_ROOT: str = os.path.join(BASE_DIR, 'media')
 
 MAIN_PAGE = os.environ.get('MAIN_PAGE', '')
 
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 

--- a/src/signal_documentation/settings.py
+++ b/src/signal_documentation/settings.py
@@ -181,6 +181,8 @@ MEDIA_URL: str = '/media/'
 MEDIA_ROOT: str = os.path.join(BASE_DIR, 'media')
 
 
+MAIN_PAGE = os.environ.get('MAIN_PAGE', '')
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 

--- a/src/signal_documentation/urls.py
+++ b/src/signal_documentation/urls.py
@@ -38,7 +38,7 @@ handler500 = InternalServerErrorView.as_view()
 urlpatterns: list[URLResolver] = [
     path('admin/', admin.site.urls),
     path('__debug__/', include('debug_toolbar.urls')),
-    path('', include('signals.urls')),
+    path(settings.MAIN_PAGE, include('signals.urls')),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)  # type: ignore


### PR DESCRIPTION
The changes made in this PR include:
- Added `MAIN_PAGE` variable to `settings.py` file.
- Modified `urls.py` file to include `settings.MAIN_PAGE` in the path.

These changes add a new variable `MAIN_PAGE` to the `settings.py` file, which retrieves its value from the environment variable `MAIN_PAGE`. In the `urls.py` file, the path for the signals app is modified to include `settings.MAIN_PAGE` as the prefix for the URL.