### PR TITLE
SD-30 Leaving `MAIN_PAGE` unset causes errors

### DIFF
--- a/src/signal_documentation/urls.py
+++ b/src/signal_documentation/urls.py
@@ -38,7 +38,7 @@ handler500 = InternalServerErrorView.as_view()
 urlpatterns: list[URLResolver] = [
     path('admin/', admin.site.urls),
     path('__debug__/', include('debug_toolbar.urls')),
-    path(f'{settings.MAIN_PAGE}/', include('signals.urls')),
+    path(f'{settings.MAIN_PAGE}/' if settings.MAIN_PAGE else '', include('signals.urls')),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)  # type: ignore


### PR DESCRIPTION
The changes made in this PR include:
- Modified `src/signal_documentation/urls.py` to handle the case when `settings.MAIN_PAGE` is empty.
- Added a conditional statement to include the `signals.urls` when `settings.MAIN_PAGE` is not empty.
- This change ensures that the `signals.urls` is included in the URL patterns only when `settings.MAIN_PAGE` is not empty.