### PR TITLE
Make admin site available

### DIFF
--- a/src/signal_documentation/urls.py
+++ b/src/signal_documentation/urls.py
@@ -36,7 +36,7 @@ handler404 = NotFoundErrorView.as_view()
 handler500 = InternalServerErrorView.as_view()
 
 urlpatterns: list[URLResolver] = [
-    path('admin/', admin.site.urls),
+    path(f'{settings.MAIN_PAGE}/admin/' if settings.MAIN_PAGE else 'admin/', admin.site.urls),
     path('__debug__/', include('debug_toolbar.urls')),
     path(f'{settings.MAIN_PAGE}/' if settings.MAIN_PAGE else '', include('signals.urls')),
 ]


### PR DESCRIPTION
Right now we see this when checking out admin page. This PR makes admin site available at the correct address. 
<img width="1067" alt="Screenshot 2023-09-20 at 6 19 43 PM" src="https://github.com/cmu-delphi/signal_documentation/assets/118945681/407c7ce3-395e-40af-8035-22a05e22689b">
