### PR TITLE
add healthcheck + autoheal mechanism

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
     depends_on:
       - sdwebapp
     healthcheck:
-      test: curl -f ghcr.io/cmu-delphi/signal_documentation-nginx || exit 1
+      test: curl -f localhost/signal-documentation || exit 1
       interval: 10s
       timeout: 10s
       start_period: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,8 +57,28 @@ services:
       - ./src/staticfiles:/staticfiles
     ports:
       - "80:80"
+    labels:
+      - "autoheal=true"
     depends_on:
       - sdwebapp
+    healthcheck:
+      test: curl -f ghcr.io/cmu-delphi/signal_documentation-nginx || exit 1
+      interval: 10s
+      timeout: 10s
+      start_period: 10s
+      retries: 3
+
+  autoheal:
+    image: willfarrell/autoheal:latest
+    tty: true
+    restart: always
+    environment:
+      - AUTOHEAL_INTERVAL=60
+      - AUTOHEAL_START_PERIOD=300
+      - AUTOHEAL_DEFAULT_STOP_TIMEOUT=10
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   mysql:
   webapp:


### PR DESCRIPTION
nginx returns 502 whenever app container is restarted. This PR fix that by restarting nginx container automatically every time it can't reach signal-documentation main page. 