### PR TITLE
Fixed infinite scroll

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -51,7 +51,7 @@
             </li>
 
             <li class="nav-item">
-                <a class="nav-link" href="#">
+                <a class="nav-link" href="{% url 'datasources' %}">
                   <i class="ri-stack-line"></i>
                   <span>Sources</span>
                 </a>

--- a/src/templates/signals/signals_list.html
+++ b/src/templates/signals/signals_list.html
@@ -1,6 +1,6 @@
 {% for signal in signals %}
     {% if forloop.last %}
-        <tr hx-trigger="revealed" class="clickable-table-row" hx-get="{% url 'signals' %}?page={{ page_obj.number|add:1 }}"
+        <tr hx-trigger="revealed" class="clickable-table-row" hx-get="{% url 'signals' %}?page={{ page_obj.number|add:1 }}{{ url_params_str }}"
             hx-swap="afterend" onClick="location.href='{% url 'signal' pk=signal.id %}';">
     {% else %}
         <tr classs="clickable-table-row" onClick="location.href='{% url 'signal' pk=signal.id %}';">


### PR DESCRIPTION
Before this fix, infinite scroll didn't preserve any filters, so kept loading all records despite filters.