### PR TITLE
Add gunicorn package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -39,6 +39,7 @@ django-celery-beat = "*"
 celery = {version = "*", extras = ["redis"]}
 flower = "*"
 django-htmx = "*"
+gunicorn = "*"
 
 [dev-packages]
 flake8 = "*"


### PR DESCRIPTION
It looks like this package went missing at some point, and the most recent staging container build was failing because of it. Adding it back in!