### PR TITLE
Fix a naming mismatch so that container deployments work

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -7,8 +7,7 @@ jobs:
     # CI/CD will run on these branches
     if: >
       github.ref == 'refs/heads/master' ||
-      github.ref == 'refs/heads/development' ||
-      github.ref == 'refs/heads/fix-ci-and-webhook'
+      github.ref == 'refs/heads/development'
     strategy:
       matrix:
         # Specify the docker-compose services to build images from

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -7,6 +7,7 @@ jobs:
     # CI/CD will run on these branches
     if: >
       github.ref == 'refs/heads/master' ||
+      github.ref == 'refs/heads/development' ||
       github.ref == 'refs/heads/development'
     strategy:
       matrix:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,7 +8,7 @@ jobs:
     if: >
       github.ref == 'refs/heads/master' ||
       github.ref == 'refs/heads/development' ||
-      github.ref == 'refs/heads/development'
+      github.ref == 'refs/heads/fix-ci-and-webhook'
     strategy:
       matrix:
         # Specify the docker-compose services to build images from

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Each environment is essentially a bunch of different services all governed by `d
 - A PR merged to either `development` or `master` will trigger CI to build container images that are then tagged (based on the branch name and ":latest" respectively) and stored in our GitHub Packages container image repository.
 - CI triggers a webhook that tells the host systems to pull and run new container images and restart any services that have been updated.
 
+**IMPORTANT!** - The CI/CD process uses Docker Compose to build the specific container images that will be used in external environments. Success of the the build-and-deploy workflow is dependent on constructed services in `docker-compose.yaml`. If considering making changes there, please have a PR reviewed by devops folks :pray: :pray: :pray:
+
 ### Control of the deployed environment
 
 The environment and secrets used for deployment live in <https://github.com/cmu-delphi/delphi-ansible-web>. Any changes to the environment should be made there and then tested and validated by devops folks.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,14 +18,15 @@ services:
     ports:
       - "3306:3306"
 
+  # Production service - "service", "image", and "container_name" are important!
   sdwebapp:
-    image: ${REGISTRY}signal_documentation-webapp${TAG}
+    image: ${REGISTRY}signal_documentation-sdwebapp${TAG}
     build:
       context: .
 
     env_file:
       - ./.env
-    container_name: signal_documentation-webapp
+    container_name: signal_documentation-sdwebapp
     restart: on-failure
     command: sh -c "python3 /usr/src/signal_documentation/src/manage.py migrate --noinput &&
                     python3 /usr/src/signal_documentation/src/manage.py collectstatic --noinput &&
@@ -47,13 +48,14 @@ services:
     restart: always
     ports:
       - "6379:6379"
-
+  
+  # Production service - "service", "image", and "container_name" are important!
   sdnginx:
-    image: ${REGISTRY}signal_documentation-nginx${TAG}
+    image: ${REGISTRY}signal_documentation-sdnginx${TAG}
     build: ./nginx
     env_file:
       - ./.env
-    container_name: signal_documentation-nginx
+    container_name: signal_documentation-sdnginx
     restart: on-failure
     volumes:
       - ./src/staticfiles:/staticfiles
@@ -107,7 +109,7 @@ services:
 
 volumes:
   mysql:
-  webapp:
+  sdwebapp:
   static:
   celery:
   celery-beat:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,8 @@ services:
     ports:
       - "3306:3306"
 
-  # Production service - "service", "image", and "container_name" are important!
+  # Production service - "service", "image", and "container_name" should all contain the same
+  # reference, based on the name of the service.
   sdwebapp:
     image: ${REGISTRY}signal_documentation-sdwebapp${TAG}
     build:
@@ -49,7 +50,8 @@ services:
     ports:
       - "6379:6379"
   
-  # Production service - "service", "image", and "container_name" are important!
+  # Production service - "service", "image", and "container_name" should all contain the same
+  # reference, based on the name of the service.
   sdnginx:
     image: ${REGISTRY}signal_documentation-sdnginx${TAG}
     build: ./nginx


### PR DESCRIPTION
We use docker-compose in Actions to build certain services' container images. There is a necessity for a few parts of the service definition to share a similar name. Looks like this was modified at some point, the result being that we were building a container image with one image:tag, and then telling our webhook updater to use a different image:tag. So nothing was being deployed. This PR largely fixes that.

Additionally it adds some comments and bit of extra info in the README about the process.