### PR TITLE
use api.delphi.cmu.edu instead of api.covidcast

### DIFF
--- a/src/signal_documentation/settings.py
+++ b/src/signal_documentation/settings.py
@@ -24,7 +24,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
 EPIVIS_URL = os.environ.get("EPIVIS_URL", "https://deploy-preview-36--cmu-delphi-epivis.netlify.app/")
-DATA_EXPORT_URL = os.environ.get("DATA_EXPORT_URL", "https://api.covidcast.cmu.edu/epidata/covidcast/csv")
+DATA_EXPORT_URL = os.environ.get("DATA_EXPORT_URL", "https://api.delphi.cmu.edu/epidata/covidcast/csv")
 
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 if SENTRY_DSN:

--- a/src/signal_documentation/settings.py
+++ b/src/signal_documentation/settings.py
@@ -25,6 +25,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 
 EPIVIS_URL = os.environ.get("EPIVIS_URL", "https://deploy-preview-36--cmu-delphi-epivis.netlify.app/")
 DATA_EXPORT_URL = os.environ.get("DATA_EXPORT_URL", "https://api.delphi.cmu.edu/epidata/covidcast/csv")
+COVIDCAST_URL = os.environ.get("COVIDCAST_URL", "https://api.delphi.cmu.edu/epidata/covidcast/")
 
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 if SENTRY_DSN:

--- a/src/signals/tasks.py
+++ b/src/signals/tasks.py
@@ -7,7 +7,7 @@ from rest_framework.status import is_client_error, is_server_error
 from signal_documentation.celery import BaseTaskWithRetry, app
 from signals.tools import SignalLastUpdatedParser
 
-COVID_CAST_META_URL = os.environ.get('COVID_CAST_META_URL', 'https://api.covidcast.cmu.edu/epidata/covidcast/meta')
+COVID_CAST_META_URL = os.environ.get('COVID_CAST_META_URL', 'https://api.delphi.cmu.edu/epidata/covidcast/meta')
 
 
 @app.task(bind=BaseTaskWithRetry)

--- a/src/signals/views.py
+++ b/src/signals/views.py
@@ -112,6 +112,7 @@ class SignalsDetailView(DetailView):
         context: Dict[str, Any] = super().get_context_data(**kwargs)
         context["epivis_url"] = settings.EPIVIS_URL
         context["data_export_url"] = settings.DATA_EXPORT_URL
+        context["covidcast_url"] = settings.COVIDCAST_URL
         return context
 
 

--- a/src/templates/signals/data_visualization_export.html
+++ b/src/templates/signals/data_visualization_export.html
@@ -275,7 +275,7 @@
 
             if (!requestSent) {
                 $.ajax({
-                    url: 'https://api.covidcast.cmu.edu/epidata/covidcast/',
+                    url: 'https://api.delphi.cmu.edu/epidata/covidcast/',
                     type: 'GET',
                     data: {
                         'time_type': timeType,

--- a/src/templates/signals/data_visualization_export.html
+++ b/src/templates/signals/data_visualization_export.html
@@ -275,7 +275,7 @@
 
             if (!requestSent) {
                 $.ajax({
-                    url: 'https://api.delphi.cmu.edu/epidata/covidcast/',
+                    url: '{{ covidcast_url }}',
                     type: 'GET',
                     data: {
                         'time_type': timeType,


### PR DESCRIPTION
`api.delphi.cmu.edu` is the preferred hostname