### PR TITLE
Update Sentry SDK config

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,7 +8,8 @@ jobs:
     if: >
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/development'
+      github.ref == 'refs/heads/development' ||
+      github.ref == 'refs/heads/update-sentry-config'
 
     strategy:
       matrix:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,8 +8,7 @@ jobs:
     if: >
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/development' ||
-      github.ref == 'refs/heads/update-sentry-config'
+      github.ref == 'refs/heads/development'
 
     strategy:
       matrix:

--- a/src/signal_documentation/settings.py
+++ b/src/signal_documentation/settings.py
@@ -30,13 +30,13 @@ COVIDCAST_URL = os.environ.get("COVIDCAST_URL", "https://api.delphi.cmu.edu/epid
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 if SENTRY_DSN:
     sentry_sdk.init(
-        dsn=SENTRY_DSN,
-        integrations=[DjangoIntegration(), RedisIntegration(max_data_size=0)],
-        traces_sample_rate=float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', 1.0)),
-        profiles_sample_rate=float(os.environ.get('SENTRY_PROFILES_SAMPLE_RATE', 1.0)),
-        environment=(os.environ.get('SENTRY_ENVIRONMENT', 'development')),
-        debug=(os.environ.get('SENTRY_DEBUG', 'True')),
-        attach_stacktrace=(os.environ.get('SENTRY_ATTACH_STACKTRACE', 'True'))
+        dsn = SENTRY_DSN,
+        integrations = [DjangoIntegration(), RedisIntegration(max_data_size=0)],
+        traces_sample_rate = float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', 1.0)),
+        profiles_sample_rate = float(os.environ.get('SENTRY_PROFILES_SAMPLE_RATE', 1.0)),
+        environment = (os.environ.get('SENTRY_ENVIRONMENT', 'development')),
+        attach_stacktrace = os.environ.get('SENTRY_ATTACH_STACKTRACE', 'False').lower() in ('true', '1', 't'),
+        debug = os.environ.get('SENTRY_DEBUG', 'False').lower() in ('true', '1', 't')
     )
 
 

--- a/src/signal_documentation/settings.py
+++ b/src/signal_documentation/settings.py
@@ -34,9 +34,9 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration(), RedisIntegration(max_data_size=0)],
         traces_sample_rate=float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE', 1.0)),
         profiles_sample_rate=float(os.environ.get('SENTRY_PROFILES_SAMPLE_RATE', 1.0)),
-        environment=str(os.environ.get('SENTRY_ENVIRONMENT', 'development')),
-        debug=str(os.environ.get('SENTRY_DEBUG', 'True')),
-        attach_stacktrace=str(os.environ.get('SENTRY_ATTACH_STACKTRACE', 'True'))
+        environment=(os.environ.get('SENTRY_ENVIRONMENT', 'development')),
+        debug=(os.environ.get('SENTRY_DEBUG', 'True')),
+        attach_stacktrace=(os.environ.get('SENTRY_ATTACH_STACKTRACE', 'True'))
     )
 
 


### PR DESCRIPTION
This is a slight refactor to mimic the way we have configured the Sentry SDK in delphi-epidata. It mostly addresses an issue in which the "debug" var was not being set properly and always defaulted to `True`, causing a _ton_ of extra logging.