### PR TITLE
Update static file serving config in Nginx

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,8 +8,7 @@ jobs:
     if: >
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/development' ||
-      github.ref == 'refs/heads/update-static-files-config'
+      github.ref == 'refs/heads/development'
 
 
     strategy:

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -10,7 +10,6 @@ jobs:
       github.ref == 'refs/heads/staging' ||
       github.ref == 'refs/heads/development'
 
-
     strategy:
       matrix:
         # Specify the docker-compose services to build images from

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -8,7 +8,9 @@ jobs:
     if: >
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/development'
+      github.ref == 'refs/heads/development' ||
+      github.ref == 'refs/heads/update-static-files-config'
+
 
     strategy:
       matrix:

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,13 +1,14 @@
 server {
     listen 80;
     server_name sdnginx;
+    
     location ~* /static/(.*)$ {
         autoindex on;
         alias /staticfiles/$1;
     }
 
     location / {
-        proxy_pass http://sdwebapp:8000/;
+        proxy_pass http://sdwebapp:8000;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,7 +1,12 @@
 server {
     listen 80;
     server_name sdnginx;
-    
+
+    location ~* /static/assets(.*)$ {
+        autoindex on;
+        alias /staticfiles/$1;
+    }
+
     location ~* /static/(.*)$ {
         autoindex on;
         alias /staticfiles/$1;

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,6 +1,12 @@
 server {
     listen 80;
     server_name sdnginx;
+
+    location ~* /static/assets/(.*)$ {
+        autoindex on;
+        alias /staticfiles/$1;
+    }
+
     location ~* /static/(.*)$ {
         autoindex on;
         alias /staticfiles/$1;

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,12 +1,6 @@
 server {
     listen 80;
     server_name sdnginx;
-
-    location ~* /static/assets/(.*)$ {
-        autoindex on;
-        alias /staticfiles/$1;
-    }
-
     location ~* /static/(.*)$ {
         autoindex on;
         alias /staticfiles/$1;

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -13,7 +13,7 @@ server {
     }
 
     location / {
-        proxy_pass http://sdwebapp:8000;
+        proxy_pass http://sdwebapp:8000/;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
There are two URL types used for looking up static files:

- http://MAIN_PAGE/static
- http://MAIN_PAGE/static/assets

We don't collect static files for both locations, so this updates our Nginx config to use the same alias for both URL types. We do this by adding an additional location for `/static/assets` and then pointing it the same alias we use for `/static`.